### PR TITLE
Body parser removed

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,11 @@
 const express = require('express');
 const mongoose = require('mongoose');
-const bodyParser = require('body-parser');
 
 const app = express();
 
 app.set('view engine', 'ejs');
 
-app.use(bodyParser.urlencoded({ extended: false }));
+app.use(express.urlencoded({ extended: false }));
 
 // Connect to MongoDB
 mongoose

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "body-parser": "^1.18.3",
     "ejs": "^2.6.1",
     "express": "^4.16.3",
     "mongoose": "^5.2.7"


### PR DESCRIPTION
Body parser removed, since express v4.16.0+ provides the body parser middleware.

[Express docs](https://expressjs.com/en/api.html#express.urlencoded)